### PR TITLE
[docs] Rename s3clean to s3remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ custom:
     # (optional) Whether to prompt before emptying a bucket. Default is 'false'.
     prompt: false
 
-    # Names of buckets to remove before a stack is removed, or via 'sls s3clean' command
+    # Names of buckets to remove before a stack is removed, or via 'sls s3remove' command
     buckets:
       - bucketName1
       - bucketName2

--- a/src/serverless-s3-cleaner-config.ts
+++ b/src/serverless-s3-cleaner-config.ts
@@ -5,7 +5,7 @@ interface ServerlessS3CleanerConfig {
   prompt?: boolean;
 
   /**
-   * Names of buckets to be cleaned up on remove (or by running the s3clean command).
+   * Names of buckets to be cleaned up on remove (or by running the s3remove command).
    */
   buckets?: string[];
 


### PR DESCRIPTION
Looks like you had planned to rename the plugin's command, but never did.